### PR TITLE
Fixes histogram metrics

### DIFF
--- a/src/shared/discord.ts
+++ b/src/shared/discord.ts
@@ -13,7 +13,7 @@ import type {
 import { Client, Events, Routes, User } from "discord.js";
 import assert from "node:assert";
 import loggerFactory from "pino";
-import { Histogram, exponentialBuckets } from "prom-client";
+import { Histogram } from "prom-client";
 
 // region Logger and Metrics
 const logger = loggerFactory({
@@ -21,8 +21,6 @@ const logger = loggerFactory({
 });
 
 const interactionRequestDuration = new Histogram({
-  // Create 9 buckets, starting on 10 and with a factor of 2
-  buckets: exponentialBuckets(10, 2, 9),
   help: "Interaction request duration in milliseconds",
   labelNames: ["status", "handler"],
   name: "interaction_request_duration_milliseconds",

--- a/src/shared/postgresql.ts
+++ b/src/shared/postgresql.ts
@@ -2,7 +2,7 @@ import type { PoolClient } from "pg";
 
 import { Pool } from "pg";
 import loggerFactory from "pino";
-import { Histogram, exponentialBuckets } from "prom-client";
+import { Histogram } from "prom-client";
 
 import type { Caller } from "./caller";
 
@@ -18,8 +18,6 @@ const logger = loggerFactory({
 });
 
 const databaseRequestDuration = new Histogram({
-  // Create 11 buckets, starting on 1 and with a factor of 2
-  buckets: exponentialBuckets(1, 2, 11),
   help: "Database request duration in milliseconds",
   labelNames: ["caller", "status", "connected"],
   name: "database_request_duration_milliseconds",


### PR DESCRIPTION
Setting custom buckets isn't needed for histograms that track web requests and similar metrics